### PR TITLE
Strict Type Checking Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redux-aggregate
 
-[![Latest Version](https://img.shields.io/badge/npm-v1.2.1-C12127.svg)](https://www.npmjs.com/package/redux-aggregate)
+[![Latest Version](https://img.shields.io/badge/npm-v1.3.0-C12127.svg)](https://www.npmjs.com/package/redux-aggregate)
 
 The helper module making Redux more usable.
 Inspired by [unistore](https://github.com/developit/unistore).

--- a/examples/todos-mixin/package-lock.json
+++ b/examples/todos-mixin/package-lock.json
@@ -32,6 +32,47 @@
       "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
+    "@types/react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-uZP8Fd4f7rwHKztnOhFJYEJsKXO7opmcyKk5P9vRC8UJAx3AiWaGFiLxDqPJqzO3n3IhF/v6rdscxadarEXnag==",
+      "dev": true,
+      "requires": {
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.6.tgz",
+      "integrity": "sha512-M+1zmwa5KxUpkCuxA4whlDJKYTGNvNQW4pIoCLH16xGbClicD9CzPry4y94kTjCCk/bJZCZ/GVqUsP7eKcO/mQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.2.tgz",
+      "integrity": "sha512-rNf/oxhVDPoRLpxP1d8NvdYHJe6LtyLp0ha8a/RLnsgMVBrbmPaQUznwcmAHlgCdAYFBFqntxe8OqmixHIVI5Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -196,6 +237,11 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -2018,6 +2064,12 @@
         "randomfill": "^1.0.3"
       }
     },
+    "csstype": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.5.tgz",
+      "integrity": "sha512-EGMjeoiN3aqEX5u/cyH5mSdGBDGdLcCQvcEcBWNGFSPXKd9uOTIeVG91YQ22OxI44DKpvI+4C7VUSmEpsHWJaA==",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2365,6 +2417,14 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -2867,6 +2927,27 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
       }
     },
     "figures": {
@@ -4072,6 +4153,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4288,7 +4374,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -4315,14 +4400,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.3.1.tgz",
       "integrity": "sha1-OowY2dYYyLcWl2Cnm+7CSh2mpD4="
-    },
-    "immutability-helper": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.7.1.tgz",
-      "integrity": "sha512-6uhvN9F1TRPtirUV3b7MIeY34h+U2hFR5hyK6jaWOvT36BNXYCx2tGujZhx/41fzUta/VNmK47scDhohTFYRDw==",
-      "requires": {
-        "invariant": "^2.2.0"
-      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -4745,8 +4822,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -4795,6 +4871,15 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "istextorbinary": {
       "version": "2.2.1",
@@ -5947,6 +6032,15 @@
       "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
     "node-forge": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
@@ -6603,41 +6697,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "preact": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.7.tgz",
-      "integrity": "sha512-m34Ke8U32HyKRVzUOCAcaiIBLR2ye6syiuRclU5DxyixDPDFqdLbIElhERBrF6gDbPKQR+Vpv5bZ9CCbvN6pdQ=="
-    },
-    "preact-compat": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.18.0.tgz",
-      "integrity": "sha512-4ygl49bkMyPEx2ZwkNDh2AhUa62g2lwJYIsQU4IR5zW4d4QIyucmZFr/hu2+aeFP4YVR8nVZg1KWMETpP32UkA==",
-      "requires": {
-        "immutability-helper": "^2.1.2",
-        "preact-render-to-string": "^3.6.0",
-        "preact-transition-group": "^1.1.0",
-        "prop-types": "^15.5.8",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      }
-    },
-    "preact-redux": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/preact-redux/-/preact-redux-2.0.3.tgz",
-      "integrity": "sha1-lgpTXDImQ801mY8z8MLme8Hn6qs="
-    },
-    "preact-render-to-string": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz",
-      "integrity": "sha1-fbQXdFS8ATleDQHWrAe8XoOOMe4=",
-      "requires": {
-        "pretty-format": "^3.5.1"
-      }
-    },
-    "preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
-    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -6662,11 +6721,6 @@
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
-    "pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -6684,6 +6738,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -6883,6 +6945,41 @@
           "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
           "dev": true
         }
+      }
+    },
+    "react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
       }
     },
     "read-chunk": {
@@ -7262,8 +7359,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "schema-utils": {
       "version": "0.4.5",
@@ -7394,8 +7490,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -7741,11 +7836,6 @@
       "requires": {
         "safe-buffer": "^5.1.1"
       }
-    },
-    "standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -8114,6 +8204,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
     },
     "uglify-es": {
       "version": "3.3.9",
@@ -8934,6 +9029,11 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
       "version": "1.3.1",

--- a/examples/todos-mixin/package.json
+++ b/examples/todos-mixin/package.json
@@ -7,15 +7,18 @@
   },
   "dependencies": {
     "immer": "^1.3.1",
-    "preact": "8.2.7",
-    "preact-compat": "3.18.0",
-    "preact-redux": "2.0.3",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-redux": "^5.0.7",
     "redux": "3.7.2",
     "redux-aggregate": "^1.2.1",
     "redux-devtools-extension": "2.13.2"
   },
   "devDependencies": {
     "@types/node": "9.4.6",
+    "@types/react": "^16.4.1",
+    "@types/react-dom": "^16.0.6",
+    "@types/react-redux": "^6.0.2",
     "ts-loader": "4.0.0",
     "ts-node": "5.0.0",
     "typescript": ">=2.8.0",

--- a/examples/todos-mixin/src/app.tsx
+++ b/examples/todos-mixin/src/app.tsx
@@ -1,4 +1,5 @@
-import { h, render } from 'preact'
+import * as React from 'react'
+import { render } from 'react-dom'
 import { AppProvider } from './views/root'
 import { store } from './store'
 

--- a/examples/todos-mixin/src/models/todos.ts
+++ b/examples/todos-mixin/src/models/todos.ts
@@ -7,7 +7,7 @@ import { TodoModel } from './todo'
 
 export interface TodosST {
   name: string
-  input: string
+  input: string | null
   items: TodoModel[]
 }
 export const TodosST: TodosST = {
@@ -51,6 +51,7 @@ const setItemDone = (
   { id, done }: { id: string, done: boolean }
 ): TodosST => immer(state, _state => {
   const item = _state.items.find(item => item.id === id)
+  if (item === undefined) return
   item.done = done
 })
 

--- a/examples/todos-mixin/src/store.ts
+++ b/examples/todos-mixin/src/store.ts
@@ -1,6 +1,6 @@
 import { createStore, combineReducers, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate } from '../../../src/index'
+import { createAggregate } from 'redux-aggregate'
 import { TodosPresentST, TodosPresentMT } from './models/todos_present'
 
 // ______________________________________________________

--- a/examples/todos-mixin/src/store.ts
+++ b/examples/todos-mixin/src/store.ts
@@ -1,11 +1,11 @@
-import { createStore, combineReducers, Store } from 'redux'
+import { createStore, combineReducers, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate } from 'redux-aggregate'
+import { createAggregate } from '../../../src/index'
 import { TodosPresentST, TodosPresentMT } from './models/todos_present'
 
 // ______________________________________________________
 
-export function defineStore(reducer): Store<StoreST> {
+export function defineStore<R extends ReducersMapObject>(reducer: R): Store<StoreST> {
   return createStore(
     combineReducers(reducer),
     composeWithDevTools()

--- a/examples/todos-mixin/src/views/root.tsx
+++ b/examples/todos-mixin/src/views/root.tsx
@@ -1,12 +1,12 @@
-import { h, Component } from 'preact'
+import * as React from 'react'
 import { Store } from 'redux'
-import { Provider} from 'preact-redux'
+import { Provider } from 'react-redux'
 import { StoreST } from '../store'
 import { TodosContainer } from './todos'
 
 // ______________________________________________________
 
-export class AppProvider extends Component<{ store: Store<StoreST> }, null> {
+export class AppProvider extends React.Component<{ store: Store<StoreST> }, never> {
   render() {
     return (
       <Provider store={this.props.store}>

--- a/examples/todos-mixin/src/views/todos.tsx
+++ b/examples/todos-mixin/src/views/todos.tsx
@@ -1,5 +1,5 @@
-import { h } from 'preact'
-import { connect } from 'preact-redux'
+import * as React from 'react'
+import { connect } from 'react-redux'
 import { StoreST, Todos } from '../store'
 import { TodosPresentQR } from '../models/todos_present'
 import { TodoModel } from '../models/todo';

--- a/examples/todos-mixin/src/views/todos.tsx
+++ b/examples/todos-mixin/src/views/todos.tsx
@@ -38,6 +38,7 @@ export const TodosContainer = connect(
     />
     {p.items.map(todo =>
       <TodoItem
+        key={todo.id}
         todo={todo}
         handleClickDone={p.handleClickDone}
       />

--- a/examples/todos-mixin/tsconfig.json
+++ b/examples/todos-mixin/tsconfig.json
@@ -3,11 +3,12 @@
     "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedParameters": true,
     "removeComments": true,
+    "strictNullChecks": true,
     "jsx": "react",
-    "jsxFactory": "h",
     "lib": [
       "es5",
       "dom",
@@ -19,6 +20,7 @@
     "./src/**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "webpack.config.ts"
   ]
 }

--- a/examples/todos-mixin/webpack.config.ts
+++ b/examples/todos-mixin/webpack.config.ts
@@ -21,11 +21,7 @@ const module = {
 
 const resolve = {
   extensions: [ '.js', '.ts', '.tsx' ],
-  alias: {
-    '~': `${SRC}`,
-    'react': 'preact-compat',
-    'react-dom': 'preact-compat'
-  }
+  alias: { '~': `${SRC}` }
 }
 
 // _____________

--- a/examples/todos/package-lock.json
+++ b/examples/todos/package-lock.json
@@ -16,6 +16,47 @@
       "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
+    "@types/react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-uZP8Fd4f7rwHKztnOhFJYEJsKXO7opmcyKk5P9vRC8UJAx3AiWaGFiLxDqPJqzO3n3IhF/v6rdscxadarEXnag==",
+      "dev": true,
+      "requires": {
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.6.tgz",
+      "integrity": "sha512-M+1zmwa5KxUpkCuxA4whlDJKYTGNvNQW4pIoCLH16xGbClicD9CzPry4y94kTjCCk/bJZCZ/GVqUsP7eKcO/mQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.2.tgz",
+      "integrity": "sha512-rNf/oxhVDPoRLpxP1d8NvdYHJe6LtyLp0ha8a/RLnsgMVBrbmPaQUznwcmAHlgCdAYFBFqntxe8OqmixHIVI5Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -1993,6 +2034,12 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "csstype": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.5.tgz",
+      "integrity": "sha512-EGMjeoiN3aqEX5u/cyH5mSdGBDGdLcCQvcEcBWNGFSPXKd9uOTIeVG91YQ22OxI44DKpvI+4C7VUSmEpsHWJaA==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4369,6 +4416,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4610,14 +4662,6 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
-    },
-    "immutability-helper": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.6.tgz",
-      "integrity": "sha512-CdLyZ9QuiWGk884SKhRvi8xjtB2PYMCBwa6fc8wZ5QltrdFEhwGz0upikzvjxjrDbsGs7qhgIUIMvI2YFywihA==",
-      "requires": {
-        "invariant": "^2.2.0"
-      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -6891,41 +6935,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "preact": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.7.tgz",
-      "integrity": "sha512-m34Ke8U32HyKRVzUOCAcaiIBLR2ye6syiuRclU5DxyixDPDFqdLbIElhERBrF6gDbPKQR+Vpv5bZ9CCbvN6pdQ=="
-    },
-    "preact-compat": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.18.0.tgz",
-      "integrity": "sha512-4ygl49bkMyPEx2ZwkNDh2AhUa62g2lwJYIsQU4IR5zW4d4QIyucmZFr/hu2+aeFP4YVR8nVZg1KWMETpP32UkA==",
-      "requires": {
-        "immutability-helper": "^2.1.2",
-        "preact-render-to-string": "^3.6.0",
-        "preact-transition-group": "^1.1.0",
-        "prop-types": "^15.5.8",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      }
-    },
-    "preact-redux": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/preact-redux/-/preact-redux-2.0.3.tgz",
-      "integrity": "sha1-lgpTXDImQ801mY8z8MLme8Hn6qs="
-    },
-    "preact-render-to-string": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz",
-      "integrity": "sha1-fbQXdFS8ATleDQHWrAe8XoOOMe4=",
-      "requires": {
-        "pretty-format": "^3.5.1"
-      }
-    },
-    "preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
-    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -6949,11 +6958,6 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
-    },
-    "pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
     },
     "private": {
       "version": "0.1.8",
@@ -7150,6 +7154,41 @@
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
+      }
+    },
+    "react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
       }
     },
     "read-chunk": {
@@ -8043,11 +8082,6 @@
       "requires": {
         "safe-buffer": "^5.1.1"
       }
-    },
-    "standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -6,15 +6,18 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "preact": "8.2.7",
-    "preact-compat": "3.18.0",
-    "preact-redux": "2.0.3",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-redux": "^5.0.7",
     "redux": "3.7.2",
     "redux-aggregate": "^1.2.1",
     "redux-devtools-extension": "2.13.2"
   },
   "devDependencies": {
     "@types/node": "9.4.6",
+    "@types/react": "^16.4.1",
+    "@types/react-dom": "^16.0.6",
+    "@types/react-redux": "^6.0.2",
     "ts-loader": "4.0.0",
     "ts-node": "5.0.0",
     "typescript": ">=2.8.0",

--- a/examples/todos/src/app.tsx
+++ b/examples/todos/src/app.tsx
@@ -1,4 +1,5 @@
-import { h, render } from 'preact'
+import * as React from 'react'
+import { render } from 'react-dom'
 import { AppProvider } from './views/root'
 import { store } from './store'
 

--- a/examples/todos/src/models/todo.ts
+++ b/examples/todos/src/models/todo.ts
@@ -1,15 +1,22 @@
+import { uuid } from './uuid'
+
 // ______________________________________________________
 //
 // @ TodoModel State
 
+type Injects<T> = { [P in keyof T]?: T[P] }
 export interface TodoST {
-  value: string
+  id: string
   date: Date
+  value: string
+  done: boolean
 }
-export const TodoST: TodoST = {
+export const TodoST = (): TodoST => ({
+  id: uuid(),
+  date: new Date(),
   value: '',
-  date: new Date()
-}
+  done: false
+})
 
 // ______________________________________________________
 //
@@ -27,4 +34,4 @@ export const TodoQR = {
   getDateLabel
 }
 export interface TodoModel extends TodoST {}
-export const TodoModel = (injects: TodoST): TodoST => ({ ...TodoST, ...injects })
+export const TodoModel = (injects: Injects<TodoST>): TodoST => ({ ...TodoST(), ...injects })

--- a/examples/todos/src/models/todos.ts
+++ b/examples/todos/src/models/todos.ts
@@ -6,7 +6,7 @@ import { TodoModel } from './todo'
 
 export interface TodosST {
   name: string
-  input: string | number
+  input: string | null
   items: TodoModel[]
 }
 export const TodosST: TodosST = {
@@ -33,13 +33,13 @@ export const TodosQR = {
 
 function addTodo(state: TodosST): TodosST {
   const value = TodosQR.getInputValue(state)
-  if (value === '') return
+  if (value === '') return state
   const todo = TodoModel({ value, date: new Date() })
   const items = [...state.items]
   items.push(todo)
   return { ...state, items, input: '' }
 }
-function setInputValue(state: TodosST, value: string | number): TodosST {
+function setInputValue(state: TodosST, value: string | null): TodosST {
   return { ...state, input: value }
 }
 export const TodosMT = {

--- a/examples/todos/src/models/uuid.ts
+++ b/examples/todos/src/models/uuid.ts
@@ -1,0 +1,14 @@
+export function uuid () {
+  let chars = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.split('')
+  for (let i = 0, len = chars.length; i < len; i++) {
+    switch (chars[i]) {
+      case 'x':
+        chars[i] = Math.floor(Math.random() * 16).toString(16)
+        break
+      case 'y':
+        chars[i] = (Math.floor(Math.random() * 4) + 8).toString(16)
+        break
+    }
+  }
+  return chars.join('')
+}

--- a/examples/todos/src/store.ts
+++ b/examples/todos/src/store.ts
@@ -1,11 +1,11 @@
-import { createStore, combineReducers, Store } from 'redux'
+import { createStore, combineReducers, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate } from 'redux-aggregate'
+import { createAggregate } from '../../../src/index'
 import { TodosST, TodosMT } from './models/todos'
 
 // ______________________________________________________
 
-export function defineStore(reducer): Store<StoreST> {
+export function defineStore<R extends ReducersMapObject>(reducer: R): Store<StoreST> {
   return createStore(
     combineReducers(reducer),
     composeWithDevTools()

--- a/examples/todos/src/store.ts
+++ b/examples/todos/src/store.ts
@@ -1,6 +1,6 @@
 import { createStore, combineReducers, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate } from '../../../src/index'
+import { createAggregate } from 'redux-aggregate'
 import { TodosST, TodosMT } from './models/todos'
 
 // ______________________________________________________

--- a/examples/todos/src/views/root.tsx
+++ b/examples/todos/src/views/root.tsx
@@ -1,12 +1,12 @@
-import { h, Component } from 'preact'
+import * as React from 'react'
 import { Store } from 'redux'
-import { Provider} from 'preact-redux'
+import { Provider } from 'react-redux'
 import { StoreST } from '../store'
 import { TodosContainer } from './todos'
 
 // ______________________________________________________
 
-export class AppProvider extends Component<{ store: Store<StoreST> }, null> {
+export class AppProvider extends React.Component<{ store: Store<StoreST> }, never> {
   render() {
     return (
       <Provider store={this.props.store}>

--- a/examples/todos/src/views/todos.tsx
+++ b/examples/todos/src/views/todos.tsx
@@ -1,5 +1,5 @@
-import { h } from 'preact'
-import { connect } from 'preact-redux'
+import * as React from 'react'
+import { connect } from 'react-redux'
 import { StoreST, Todos } from '../store'
 import { TodosQR } from '../models/todos'
 import { TodoModel, TodoQR } from '../models/todo'

--- a/examples/todos/src/views/todos.tsx
+++ b/examples/todos/src/views/todos.tsx
@@ -28,6 +28,7 @@ export const TodosContainer = connect(
     />
     {p.items.map(todo =>
       <TodoItem
+        key={todo.id}
         todo={todo}
       />
     )}

--- a/examples/todos/tsconfig.json
+++ b/examples/todos/tsconfig.json
@@ -3,11 +3,12 @@
     "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedParameters": true,
     "removeComments": true,
+    "strictNullChecks": true,
     "jsx": "react",
-    "jsxFactory": "h",
     "lib": [
       "es5",
       "dom",
@@ -19,6 +20,7 @@
     "./src/**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "webpack.config.ts"
   ]
 }

--- a/examples/todos/webpack.config.ts
+++ b/examples/todos/webpack.config.ts
@@ -21,11 +21,7 @@ const module = {
 
 const resolve = {
   extensions: [ '.js', '.ts', '.tsx' ],
-  alias: {
-    '~': `${SRC}`,
-    'react': 'preact-compat',
-    'react-dom': 'preact-compat'
-  }
+  alias: { '~': `${SRC}` }
 }
 
 // _____________

--- a/examples/with-rx/package-lock.json
+++ b/examples/with-rx/package-lock.json
@@ -16,6 +16,47 @@
       "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
+    "@types/react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-uZP8Fd4f7rwHKztnOhFJYEJsKXO7opmcyKk5P9vRC8UJAx3AiWaGFiLxDqPJqzO3n3IhF/v6rdscxadarEXnag==",
+      "dev": true,
+      "requires": {
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.6.tgz",
+      "integrity": "sha512-M+1zmwa5KxUpkCuxA4whlDJKYTGNvNQW4pIoCLH16xGbClicD9CzPry4y94kTjCCk/bJZCZ/GVqUsP7eKcO/mQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.2.tgz",
+      "integrity": "sha512-rNf/oxhVDPoRLpxP1d8NvdYHJe6LtyLp0ha8a/RLnsgMVBrbmPaQUznwcmAHlgCdAYFBFqntxe8OqmixHIVI5Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -1993,6 +2034,12 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "csstype": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.5.tgz",
+      "integrity": "sha512-EGMjeoiN3aqEX5u/cyH5mSdGBDGdLcCQvcEcBWNGFSPXKd9uOTIeVG91YQ22OxI44DKpvI+4C7VUSmEpsHWJaA==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4374,6 +4421,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4615,14 +4667,6 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
-    },
-    "immutability-helper": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.6.tgz",
-      "integrity": "sha512-CdLyZ9QuiWGk884SKhRvi8xjtB2PYMCBwa6fc8wZ5QltrdFEhwGz0upikzvjxjrDbsGs7qhgIUIMvI2YFywihA==",
-      "requires": {
-        "invariant": "^2.2.0"
-      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -6896,41 +6940,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "preact": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.7.tgz",
-      "integrity": "sha512-m34Ke8U32HyKRVzUOCAcaiIBLR2ye6syiuRclU5DxyixDPDFqdLbIElhERBrF6gDbPKQR+Vpv5bZ9CCbvN6pdQ=="
-    },
-    "preact-compat": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.18.0.tgz",
-      "integrity": "sha512-4ygl49bkMyPEx2ZwkNDh2AhUa62g2lwJYIsQU4IR5zW4d4QIyucmZFr/hu2+aeFP4YVR8nVZg1KWMETpP32UkA==",
-      "requires": {
-        "immutability-helper": "^2.1.2",
-        "preact-render-to-string": "^3.6.0",
-        "preact-transition-group": "^1.1.0",
-        "prop-types": "^15.5.8",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      }
-    },
-    "preact-redux": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/preact-redux/-/preact-redux-2.0.3.tgz",
-      "integrity": "sha1-lgpTXDImQ801mY8z8MLme8Hn6qs="
-    },
-    "preact-render-to-string": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz",
-      "integrity": "sha1-fbQXdFS8ATleDQHWrAe8XoOOMe4=",
-      "requires": {
-        "pretty-format": "^3.5.1"
-      }
-    },
-    "preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
-    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -6954,11 +6963,6 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
-    },
-    "pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
     },
     "private": {
       "version": "0.1.8",
@@ -7155,6 +7159,41 @@
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
+      }
+    },
+    "react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
       }
     },
     "read-chunk": {
@@ -8054,11 +8093,6 @@
       "requires": {
         "safe-buffer": "^5.1.1"
       }
-    },
-    "standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/examples/with-rx/package.json
+++ b/examples/with-rx/package.json
@@ -6,9 +6,9 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "preact": "8.2.7",
-    "preact-compat": "3.18.0",
-    "preact-redux": "2.0.3",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-redux": "^5.0.7",
     "redux": "3.7.2",
     "redux-aggregate": "^1.2.1",
     "redux-devtools-extension": "2.13.2",
@@ -17,6 +17,9 @@
   },
   "devDependencies": {
     "@types/node": "9.4.6",
+    "@types/react": "^16.4.1",
+    "@types/react-dom": "^16.0.6",
+    "@types/react-redux": "^6.0.2",
     "ts-loader": "4.0.0",
     "ts-node": "5.0.0",
     "typescript": ">=2.8.0",

--- a/examples/with-rx/src/app.tsx
+++ b/examples/with-rx/src/app.tsx
@@ -1,4 +1,5 @@
-import { h, render } from 'preact'
+import * as React from 'react'
+import { render } from 'react-dom'
 import { AppProvider } from './views/root'
 import { store } from './store'
 

--- a/examples/with-rx/src/models/todo.ts
+++ b/examples/with-rx/src/models/todo.ts
@@ -1,19 +1,26 @@
+import { uuid } from './uuid'
+
 // ______________________________________________________
 //
-// @ State
+// @ TodoModel State
 
+type Injects<T> = { [P in keyof T]?: T[P] }
 export interface TodoST {
-  value: string
+  id: string
   date: Date
+  value: string
+  done: boolean
 }
-export const TodoST: TodoST = {
+export const TodoST = (): TodoST => ({
+  id: uuid(),
+  date: new Date(),
   value: '',
-  date: new Date()
-}
+  done: false
+})
 
 // ______________________________________________________
 //
-// @ Queries
+// @ TodoModel Queries
 
 function getDateLabel({ date }: TodoST): string {
   const month = date.getMonth() + 1
@@ -26,6 +33,5 @@ function getDateLabel({ date }: TodoST): string {
 export const TodoQR = {
   getDateLabel
 }
-
 export interface TodoModel extends TodoST {}
-export const TodoModel = (injects: TodoST): TodoST => ({ ...TodoST, ...injects })
+export const TodoModel = (injects: Injects<TodoST>): TodoST => ({ ...TodoST(), ...injects })

--- a/examples/with-rx/src/models/todos.ts
+++ b/examples/with-rx/src/models/todos.ts
@@ -6,7 +6,7 @@ import { TodoModel } from './todo'
 
 export interface TodosST {
   name: string
-  input: string | number
+  input: string | null
   items: TodoModel[]
 }
 export const TodosST: TodosST = {
@@ -33,13 +33,13 @@ export const TodosQR = {
 
 function addTodo(state: TodosST): TodosST {
   const value = TodosQR.getInputValue(state)
-  if (value === '') return
+  if (value === '') return state
   const todo = TodoModel({ value, date: new Date() })
   const items = [...state.items]
   items.push(todo)
   return { ...state, items, input: '' }
 }
-function setInputValue(state: TodosST, value: string | number): TodosST {
+function setInputValue(state: TodosST, value: string | null): TodosST {
   return { ...state, input: value }
 }
 export const TodosMT = {

--- a/examples/with-rx/src/models/uuid.ts
+++ b/examples/with-rx/src/models/uuid.ts
@@ -1,0 +1,14 @@
+export function uuid () {
+  let chars = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.split('')
+  for (let i = 0, len = chars.length; i < len; i++) {
+    switch (chars[i]) {
+      case 'x':
+        chars[i] = Math.floor(Math.random() * 16).toString(16)
+        break
+      case 'y':
+        chars[i] = (Math.floor(Math.random() * 4) + 8).toString(16)
+        break
+    }
+  }
+  return chars.join('')
+}

--- a/examples/with-rx/src/services/counter.ts
+++ b/examples/with-rx/src/services/counter.ts
@@ -1,12 +1,14 @@
-import 'rxjs'
+import 'rxjs/add/operator/map'
+import { Store, Action } from 'redux'
+import { Epic, combineEpics } from 'redux-observable'
 import { Counter, Todos } from '../store'
-import { combineEpics } from 'redux-observable'
+import { StoreST } from '../store'
 
-function mapTodosCountToCounter(action$, store) {
+const mapTodosCountToCounter: Epic<Action, StoreST> = (action$, store: Store<StoreST>) => {
   const { setTodoCount } = Counter.creators
   return action$
     .ofType(Todos.types.addTodo)
-    .map(action => {
+    .map(() => {
       const length = store.getState().todos.items.length
       return setTodoCount(length)
     })

--- a/examples/with-rx/src/store.ts
+++ b/examples/with-rx/src/store.ts
@@ -1,7 +1,7 @@
 import { createStore, combineReducers, applyMiddleware, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import { createEpicMiddleware } from 'redux-observable'
-import { createAggregate } from '../../../src/index'
+import { createAggregate } from 'redux-aggregate'
 import { rootEpic} from './services/counter'
 import { CounterST, CounterMT } from './models/counter'
 import { TodosST, TodosMT } from './models/todos'

--- a/examples/with-rx/src/store.ts
+++ b/examples/with-rx/src/store.ts
@@ -1,14 +1,14 @@
-import { createStore, combineReducers, applyMiddleware, Store } from 'redux'
+import { createStore, combineReducers, applyMiddleware, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import { createEpicMiddleware } from 'redux-observable'
-import { createAggregate, } from 'redux-aggregate'
+import { createAggregate } from '../../../src/index'
 import { rootEpic} from './services/counter'
 import { CounterST, CounterMT } from './models/counter'
 import { TodosST, TodosMT } from './models/todos'
 
 // ______________________________________________________
 
-export function defineStore(reducer): Store<StoreST> {
+export function defineStore<R extends ReducersMapObject>(reducer: R): Store<StoreST> {
   return createStore(
     combineReducers(reducer),
     composeWithDevTools(

--- a/examples/with-rx/src/views/counter.tsx
+++ b/examples/with-rx/src/views/counter.tsx
@@ -1,5 +1,5 @@
-import { h } from 'preact'
-import { connect } from 'preact-redux'
+import * as React from 'react'
+import { connect } from 'react-redux'
 import { StoreST, Counter } from '../store'
 import { CounterQR } from '../models/counter'
 

--- a/examples/with-rx/src/views/root.tsx
+++ b/examples/with-rx/src/views/root.tsx
@@ -1,13 +1,13 @@
-import { h, Component } from 'preact'
+import * as React from 'react'
 import { Store } from 'redux'
-import { Provider} from 'preact-redux'
+import { Provider } from 'react-redux'
 import { StoreST } from '../store'
 import { CounterContainer } from './counter'
 import { TodosContainer } from './todos'
 
 // ______________________________________________________
 
-class RootView extends Component<null, null> {
+class RootView extends React.Component<{}, never> {
   render() {
     return (
       <div>
@@ -17,7 +17,7 @@ class RootView extends Component<null, null> {
     )
   }
 }
-export class AppProvider extends Component<{ store: Store<StoreST> }, null> {
+export class AppProvider extends React.Component<{ store: Store<StoreST> }, never> {
   render() {
     return (
       <Provider store={this.props.store}>

--- a/examples/with-rx/src/views/todos.tsx
+++ b/examples/with-rx/src/views/todos.tsx
@@ -1,5 +1,5 @@
-import { h } from 'preact'
-import { connect } from 'preact-redux'
+import * as React from 'react'
+import { connect } from 'react-redux'
 import { StoreST, Todos } from '../store'
 import { TodosQR } from '../models/todos'
 import { TodoModel, TodoQR } from '../models/todo'

--- a/examples/with-rx/src/views/todos.tsx
+++ b/examples/with-rx/src/views/todos.tsx
@@ -28,6 +28,7 @@ export const TodosContainer = connect(
     />
     {p.items.map(todo =>
       <TodoItem
+        key={todo.id}
         todo={todo}
       />
     )}

--- a/examples/with-rx/tsconfig.json
+++ b/examples/with-rx/tsconfig.json
@@ -3,11 +3,12 @@
     "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedParameters": true,
     "removeComments": true,
+    "strictNullChecks": true,
     "jsx": "react",
-    "jsxFactory": "h",
     "lib": [
       "es5",
       "dom",
@@ -19,6 +20,7 @@
     "./src/**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "webpack.config.ts"
   ]
 }

--- a/examples/with-rx/webpack.config.ts
+++ b/examples/with-rx/webpack.config.ts
@@ -21,11 +21,7 @@ const module = {
 
 const resolve = {
   extensions: [ '.js', '.ts', '.tsx' ],
-  alias: {
-    '~': `${SRC}`,
-    'react': 'preact-compat',
-    'react-dom': 'preact-compat'
-  }
+  alias: { '~': `${SRC}` }
 }
 
 // _____________

--- a/examples/with-thunk/package-lock.json
+++ b/examples/with-thunk/package-lock.json
@@ -16,6 +16,47 @@
       "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
+    "@types/react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-uZP8Fd4f7rwHKztnOhFJYEJsKXO7opmcyKk5P9vRC8UJAx3AiWaGFiLxDqPJqzO3n3IhF/v6rdscxadarEXnag==",
+      "dev": true,
+      "requires": {
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.6.tgz",
+      "integrity": "sha512-M+1zmwa5KxUpkCuxA4whlDJKYTGNvNQW4pIoCLH16xGbClicD9CzPry4y94kTjCCk/bJZCZ/GVqUsP7eKcO/mQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.2.tgz",
+      "integrity": "sha512-rNf/oxhVDPoRLpxP1d8NvdYHJe6LtyLp0ha8a/RLnsgMVBrbmPaQUznwcmAHlgCdAYFBFqntxe8OqmixHIVI5Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -1993,6 +2034,12 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "csstype": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.5.tgz",
+      "integrity": "sha512-EGMjeoiN3aqEX5u/cyH5mSdGBDGdLcCQvcEcBWNGFSPXKd9uOTIeVG91YQ22OxI44DKpvI+4C7VUSmEpsHWJaA==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4369,6 +4416,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4610,14 +4662,6 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
-    },
-    "immutability-helper": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.6.tgz",
-      "integrity": "sha512-CdLyZ9QuiWGk884SKhRvi8xjtB2PYMCBwa6fc8wZ5QltrdFEhwGz0upikzvjxjrDbsGs7qhgIUIMvI2YFywihA==",
-      "requires": {
-        "invariant": "^2.2.0"
-      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -6891,41 +6935,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "preact": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.7.tgz",
-      "integrity": "sha512-m34Ke8U32HyKRVzUOCAcaiIBLR2ye6syiuRclU5DxyixDPDFqdLbIElhERBrF6gDbPKQR+Vpv5bZ9CCbvN6pdQ=="
-    },
-    "preact-compat": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.18.0.tgz",
-      "integrity": "sha512-4ygl49bkMyPEx2ZwkNDh2AhUa62g2lwJYIsQU4IR5zW4d4QIyucmZFr/hu2+aeFP4YVR8nVZg1KWMETpP32UkA==",
-      "requires": {
-        "immutability-helper": "^2.1.2",
-        "preact-render-to-string": "^3.6.0",
-        "preact-transition-group": "^1.1.0",
-        "prop-types": "^15.5.8",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      }
-    },
-    "preact-redux": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/preact-redux/-/preact-redux-2.0.3.tgz",
-      "integrity": "sha1-lgpTXDImQ801mY8z8MLme8Hn6qs="
-    },
-    "preact-render-to-string": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz",
-      "integrity": "sha1-fbQXdFS8ATleDQHWrAe8XoOOMe4=",
-      "requires": {
-        "pretty-format": "^3.5.1"
-      }
-    },
-    "preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
-    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -6949,11 +6958,6 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
-    },
-    "pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
     },
     "private": {
       "version": "0.1.8",
@@ -7152,6 +7156,41 @@
         "unpipe": "1.0.0"
       }
     },
+    "react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
+      }
+    },
     "read-chunk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
@@ -7274,9 +7313,9 @@
       "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0="
     },
     "redux-thunk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-      "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "regenerate": {
       "version": "1.3.3",
@@ -8048,11 +8087,6 @@
       "requires": {
         "safe-buffer": "^5.1.1"
       }
-    },
-    "standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/examples/with-thunk/package.json
+++ b/examples/with-thunk/package.json
@@ -6,16 +6,19 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "preact": "8.2.7",
-    "preact-compat": "3.18.0",
-    "preact-redux": "2.0.3",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-redux": "^5.0.7",
     "redux": "3.7.2",
     "redux-aggregate": "^1.2.1",
     "redux-devtools-extension": "2.13.2",
-    "redux-thunk": "2.2.0"
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "@types/node": "9.4.6",
+    "@types/react": "^16.4.1",
+    "@types/react-dom": "^16.0.6",
+    "@types/react-redux": "^6.0.2",
     "ts-loader": "4.0.0",
     "ts-node": "5.0.0",
     "typescript": ">=2.8.0",

--- a/examples/with-thunk/src/app.tsx
+++ b/examples/with-thunk/src/app.tsx
@@ -1,4 +1,5 @@
-import { h, render } from 'preact'
+import * as React from 'react'
+import { render } from 'react-dom'
 import { AppProvider } from './views/root'
 import { store } from './store'
 

--- a/examples/with-thunk/src/store.ts
+++ b/examples/with-thunk/src/store.ts
@@ -1,6 +1,6 @@
 import { createStore, combineReducers, applyMiddleware, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate } from '../../../src/index'
+import { createAggregate } from 'redux-aggregate'
 import thunk from 'redux-thunk'
 import { CounterST, CounterMT } from './models/counter'
 

--- a/examples/with-thunk/src/store.ts
+++ b/examples/with-thunk/src/store.ts
@@ -1,12 +1,12 @@
-import { createStore, combineReducers, applyMiddleware, Store } from 'redux'
+import { createStore, combineReducers, applyMiddleware, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate, } from 'redux-aggregate'
+import { createAggregate } from '../../../src/index'
 import thunk from 'redux-thunk'
 import { CounterST, CounterMT } from './models/counter'
 
 // ______________________________________________________
 
-export function defineStore(reducer): Store<StoreST> {
+export function defineStore<R extends ReducersMapObject>(reducer: R): Store<StoreST> {
   return createStore(
     combineReducers(reducer),
     composeWithDevTools(applyMiddleware(thunk))

--- a/examples/with-thunk/src/thunks/counter.ts
+++ b/examples/with-thunk/src/thunks/counter.ts
@@ -1,4 +1,7 @@
-import { Counter } from '../store'
+import { Action } from 'redux'
+import { ThunkAction } from 'redux-thunk'
+import { Counter, StoreST } from '../store'
+type ThunkAsyncReturn = ThunkAction<Promise<void>, StoreST, null, Action>
 
 function wait () {
   return new Promise(resolve => {
@@ -6,14 +9,14 @@ function wait () {
   })
 }
 
-export function startAutoIncrement () {
+export function startAutoIncrement (): ThunkAsyncReturn {
   const { toggleAutoIncrement, increment } = Counter.creators
   return async (dispatch, getState) => {
     dispatch(toggleAutoIncrement())
     while (true) {
       await wait()
-      const { autoIncrement } = getState().counter
-      if (!autoIncrement) break
+      const { counter } = getState()
+      if (!counter.autoIncrement) break
       dispatch(increment())
     }
   }

--- a/examples/with-thunk/src/views/counter.tsx
+++ b/examples/with-thunk/src/views/counter.tsx
@@ -1,5 +1,5 @@
-import { h } from 'preact'
-import { connect } from 'preact-redux'
+import * as React from 'react'
+import { connect } from 'react-redux'
 import { StoreST, Counter } from '../store'
 import { CounterQR } from '../models/counter'
 import * as CounterThunks from '../thunks/counter'

--- a/examples/with-thunk/src/views/root.tsx
+++ b/examples/with-thunk/src/views/root.tsx
@@ -1,12 +1,12 @@
-import { h, Component } from 'preact'
+import * as React from 'react'
 import { Store } from 'redux'
-import { Provider} from 'preact-redux'
+import { Provider } from 'react-redux'
 import { StoreST } from '../store'
 import { CounterContainer } from './counter'
 
 // ______________________________________________________
 
-export class AppProvider extends Component<{ store: Store<StoreST> }, null> {
+export class AppProvider extends React.Component<{ store: Store<StoreST> }, never> {
   render() {
     return (
       <Provider store={this.props.store}>

--- a/examples/with-thunk/tsconfig.json
+++ b/examples/with-thunk/tsconfig.json
@@ -3,11 +3,12 @@
     "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedParameters": true,
     "removeComments": true,
+    "strictNullChecks": true,
     "jsx": "react",
-    "jsxFactory": "h",
     "lib": [
       "es5",
       "dom",
@@ -19,6 +20,7 @@
     "./src/**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "webpack.config.ts"
   ]
 }

--- a/examples/with-thunk/webpack.config.ts
+++ b/examples/with-thunk/webpack.config.ts
@@ -21,11 +21,7 @@ const module = {
 
 const resolve = {
   extensions: [ '.js', '.ts', '.tsx' ],
-  alias: {
-    '~': `${SRC}`,
-    'react': 'preact-compat',
-    'react-dom': 'preact-compat'
-  }
+  alias: { '~': `${SRC}` }
 }
 
 // _____________

--- a/examples/with-typescript/package-lock.json
+++ b/examples/with-typescript/package-lock.json
@@ -16,6 +16,47 @@
       "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
+    "@types/react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-uZP8Fd4f7rwHKztnOhFJYEJsKXO7opmcyKk5P9vRC8UJAx3AiWaGFiLxDqPJqzO3n3IhF/v6rdscxadarEXnag==",
+      "dev": true,
+      "requires": {
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.6.tgz",
+      "integrity": "sha512-M+1zmwa5KxUpkCuxA4whlDJKYTGNvNQW4pIoCLH16xGbClicD9CzPry4y94kTjCCk/bJZCZ/GVqUsP7eKcO/mQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.2.tgz",
+      "integrity": "sha512-rNf/oxhVDPoRLpxP1d8NvdYHJe6LtyLp0ha8a/RLnsgMVBrbmPaQUznwcmAHlgCdAYFBFqntxe8OqmixHIVI5Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -1993,6 +2034,12 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "csstype": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.5.tgz",
+      "integrity": "sha512-EGMjeoiN3aqEX5u/cyH5mSdGBDGdLcCQvcEcBWNGFSPXKd9uOTIeVG91YQ22OxI44DKpvI+4C7VUSmEpsHWJaA==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4369,6 +4416,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4610,14 +4662,6 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
-    },
-    "immutability-helper": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.6.tgz",
-      "integrity": "sha512-CdLyZ9QuiWGk884SKhRvi8xjtB2PYMCBwa6fc8wZ5QltrdFEhwGz0upikzvjxjrDbsGs7qhgIUIMvI2YFywihA==",
-      "requires": {
-        "invariant": "^2.2.0"
-      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -6891,41 +6935,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "preact": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.7.tgz",
-      "integrity": "sha512-m34Ke8U32HyKRVzUOCAcaiIBLR2ye6syiuRclU5DxyixDPDFqdLbIElhERBrF6gDbPKQR+Vpv5bZ9CCbvN6pdQ=="
-    },
-    "preact-compat": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.18.0.tgz",
-      "integrity": "sha512-4ygl49bkMyPEx2ZwkNDh2AhUa62g2lwJYIsQU4IR5zW4d4QIyucmZFr/hu2+aeFP4YVR8nVZg1KWMETpP32UkA==",
-      "requires": {
-        "immutability-helper": "^2.1.2",
-        "preact-render-to-string": "^3.6.0",
-        "preact-transition-group": "^1.1.0",
-        "prop-types": "^15.5.8",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      }
-    },
-    "preact-redux": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/preact-redux/-/preact-redux-2.0.3.tgz",
-      "integrity": "sha1-lgpTXDImQ801mY8z8MLme8Hn6qs="
-    },
-    "preact-render-to-string": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz",
-      "integrity": "sha1-fbQXdFS8ATleDQHWrAe8XoOOMe4=",
-      "requires": {
-        "pretty-format": "^3.5.1"
-      }
-    },
-    "preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
-    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -6949,11 +6958,6 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
-    },
-    "pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
     },
     "private": {
       "version": "0.1.8",
@@ -7150,6 +7154,41 @@
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
+      }
+    },
+    "react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
       }
     },
     "read-chunk": {
@@ -8043,11 +8082,6 @@
       "requires": {
         "safe-buffer": "^5.1.1"
       }
-    },
-    "standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -6,15 +6,18 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "preact": "8.2.7",
-    "preact-compat": "3.18.0",
-    "preact-redux": "2.0.3",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-redux": "^5.0.7",
     "redux": "3.7.2",
     "redux-aggregate": "^1.2.1",
     "redux-devtools-extension": "2.13.2"
   },
   "devDependencies": {
     "@types/node": "9.4.6",
+    "@types/react": "^16.4.1",
+    "@types/react-dom": "^16.0.6",
+    "@types/react-redux": "^6.0.2",
     "ts-loader": "4.0.0",
     "ts-node": "5.0.0",
     "typescript": ">=2.8.0",

--- a/examples/with-typescript/src/app.tsx
+++ b/examples/with-typescript/src/app.tsx
@@ -1,4 +1,5 @@
-import { h, render } from 'preact'
+import * as React from 'react'
+import { render } from 'react-dom'
 import { AppProvider } from './views/root'
 import { store } from './store'
 

--- a/examples/with-typescript/src/store.ts
+++ b/examples/with-typescript/src/store.ts
@@ -1,6 +1,6 @@
 import { createStore, combineReducers, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate } from '../../../src/index'
+import { createAggregate } from 'redux-aggregate'
 import { CounterMT, CounterST } from './models/counter'
 
 // ______________________________________________________

--- a/examples/with-typescript/src/store.ts
+++ b/examples/with-typescript/src/store.ts
@@ -1,11 +1,11 @@
-import { createStore, combineReducers, Store } from 'redux'
+import { createStore, combineReducers, Store, ReducersMapObject } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { createAggregate, } from 'redux-aggregate'
+import { createAggregate } from '../../../src/index'
 import { CounterMT, CounterST } from './models/counter'
 
 // ______________________________________________________
 
-export function defineStore(reducer): Store<StoreST> {
+export function defineStore<R extends ReducersMapObject>(reducer: R): Store<StoreST> {
   return createStore(
     combineReducers(reducer),
     composeWithDevTools()

--- a/examples/with-typescript/src/views/counter.tsx
+++ b/examples/with-typescript/src/views/counter.tsx
@@ -1,5 +1,5 @@
-import { h } from 'preact'
-import { connect } from 'preact-redux'
+import * as React from 'react'
+import { connect } from 'react-redux'
 import { StoreST, Counter1, Counter2, Counter3 } from '../store'
 import { CounterQR, CounterST } from '../models/counter'
 

--- a/examples/with-typescript/src/views/root.tsx
+++ b/examples/with-typescript/src/views/root.tsx
@@ -1,12 +1,12 @@
-import { h, Component } from 'preact'
+import * as React from 'react'
 import { Store } from 'redux'
-import { Provider } from 'preact-redux'
+import { Provider } from 'react-redux'
 import { StoreST } from '../store'
 import { CounterContainer1, CounterContainer2, CounterContainer3 } from './counter'
 
 // ______________________________________________________
 
-class RootView extends Component<null, null> {
+class RootView extends React.Component<{}, never> {
   render () {
     return (
       <div>
@@ -17,11 +17,11 @@ class RootView extends Component<null, null> {
     )
   }
 }
-export class AppProvider extends Component<{ store: Store<StoreST> }, null> {
+export class AppProvider extends React.Component<{ store: Store<StoreST> }, never> {
   render() {
     return (
       <Provider store={this.props.store}>
-        <RootView/>
+        <RootView />
       </Provider>
     )
   }

--- a/examples/with-typescript/tsconfig.json
+++ b/examples/with-typescript/tsconfig.json
@@ -3,11 +3,12 @@
     "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitThis": true,
+    "noUnusedParameters": true,
     "removeComments": true,
+    "strictNullChecks": true,
     "jsx": "react",
-    "jsxFactory": "h",
     "lib": [
       "es5",
       "dom",
@@ -19,6 +20,7 @@
     "./src/**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "webpack.config.ts"
   ]
 }

--- a/examples/with-typescript/webpack.config.ts
+++ b/examples/with-typescript/webpack.config.ts
@@ -21,11 +21,7 @@ const module = {
 
 const resolve = {
   extensions: [ '.js', '.ts', '.tsx' ],
-  alias: {
-    '~': `${SRC}`,
-    'react': 'preact-compat',
-    'react-dom': 'preact-compat'
-  }
+  alias: { '~': `${SRC}` }
 }
 
 // _____________

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,26 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedParameters": true,
     "removeComments": true,
-    "sourceMap": true,
+    "strictNullChecks": true,
     "jsx": "react",
-    "jsxFactory": "h",
     "lib": [
+      "es5",
       "dom",
       "es2015"
-    ],
-    "types": [
-      "jest"
     ]
-  }
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "webpack.config.ts"
+  ]
 }


### PR DESCRIPTION
The strict type check option was invalid. Enabled it and follow.
Next, the `preact-redux` type definition failed with this option. 
Therefore, replaced some examples to React.