### PR TITLE
add createSubscriber

### DIFF
--- a/__tests__/createActions.ts
+++ b/__tests__/createActions.ts
@@ -17,25 +17,25 @@ describe('createActions', () => {
 
   // @ Model
 
-  interface FollowerST {
+  interface SubscriberST {
     now: string
     name: string
   }
-  const FollowerModel: Modeler<FollowerST> = injects => ({
+  const SubscriberModel: Modeler<SubscriberST> = injects => ({
     now: '',
     name: 'unknown',
     ...injects
   })
   const mutations = {
-    setName(state: FollowerST, name: string) {
+    setName(state: SubscriberST, name: string) {
       return { ...state, name }
     }
   }
   const subscriptions = {
-    tick(state: FollowerST, now: string) {
+    tick(state: SubscriberST, now: string) {
       return { ...state, now }
     },
-    setName(state: FollowerST, name: string) {
+    setName(state: SubscriberST, name: string) {
       return { ...state, name }
     }
   }
@@ -44,11 +44,11 @@ describe('createActions', () => {
 
   const namespace = 'timer/'
   const Timer = createActions(TimerAC, namespace)
-  const Follower1 = createAggregate(mutations, 'follower1/')
-  const Follower2 = createAggregate(mutations, 'follower2/')
-  Follower1.subscribe(Timer, subscriptions)
-  Follower2.subscribe(Timer, subscriptions)
-  Follower2.subscribe(Follower1, subscriptions)
+  const Subscriber1 = createAggregate(mutations, 'subscriber1/')
+  const Subscriber2 = createAggregate(mutations, 'subscriber2/')
+  Subscriber1.subscribe(Timer, subscriptions)
+  Subscriber2.subscribe(Timer, subscriptions)
+  Subscriber2.subscribe(Subscriber1, subscriptions)
 
   // ______________________________________________________
 
@@ -78,40 +78,40 @@ describe('createActions', () => {
 
   describe('reducerFactory', () => {
     interface StoreST {
-      follower1: FollowerST
-      follower2: FollowerST
+      subscriber1: SubscriberST
+      subscriber2: SubscriberST
     }
     const store: Store<StoreST> = createStore(
       combineReducers({
-        follower1: Follower1.reducerFactory(FollowerModel({ name: 'USER_1' })),
-        follower2: Follower2.reducerFactory(FollowerModel({ name: 'USER_2' }))
+        subscriber1: Subscriber1.reducerFactory(SubscriberModel({ name: 'USER_1' })),
+        subscriber2: Subscriber2.reducerFactory(SubscriberModel({ name: 'USER_2' }))
       })
     )
 
     test('subscribers update by providers action', () => {
       const { type, payload } = Timer.creators.tick()
       const beforeState = store.getState()
-      expect(beforeState.follower1.now).not.toEqual(payload)
-      expect(beforeState.follower2.now).not.toEqual(payload)
+      expect(beforeState.subscriber1.now).not.toEqual(payload)
+      expect(beforeState.subscriber2.now).not.toEqual(payload)
 
       store.dispatch({ type, payload })
 
       const afterState = store.getState()
-      expect(afterState.follower1.now).toEqual(payload)
-      expect(afterState.follower2.now).toEqual(payload)
+      expect(afterState.subscriber1.now).toEqual(payload)
+      expect(afterState.subscriber2.now).toEqual(payload)
     })
 
     test('aggregate have behavior of action provider', () => {
-      const { type, payload } = Follower1.creators.setName('MY_NAME')
+      const { type, payload } = Subscriber1.creators.setName('MY_NAME')
       const beforeState = store.getState()
-      expect(beforeState.follower1.name).not.toEqual(payload)
-      expect(beforeState.follower2.name).not.toEqual(payload)
+      expect(beforeState.subscriber1.name).not.toEqual(payload)
+      expect(beforeState.subscriber2.name).not.toEqual(payload)
 
       store.dispatch({ type, payload })
 
       const afterState = store.getState()
-      expect(afterState.follower1.name).toEqual(payload)
-      expect(afterState.follower2.name).toEqual(payload)
+      expect(afterState.subscriber1.name).toEqual(payload)
+      expect(afterState.subscriber2.name).toEqual(payload)
     })
   })
 

--- a/__tests__/createActions.ts
+++ b/__tests__/createActions.ts
@@ -2,7 +2,6 @@ import { createStore, combineReducers, Store } from 'redux'
 import { createAggregate, Modeler, createActions } from '../src/index'
 
 describe('createActions', () => {
-
   // @ Actions
 
   function tick() {
@@ -28,15 +27,15 @@ describe('createActions', () => {
     ...injects
   })
   const mutations = {
-    setName (state: FollowerST, name: string) {
+    setName(state: FollowerST, name: string) {
       return { ...state, name }
     }
   }
   const subscriptions = {
-    tick (state: FollowerST, now: string) {
+    tick(state: FollowerST, now: string) {
       return { ...state, now }
     },
-    setName (state: FollowerST, name: string) {
+    setName(state: FollowerST, name: string) {
       return { ...state, name }
     }
   }

--- a/__tests__/createSubscriber.ts
+++ b/__tests__/createSubscriber.ts
@@ -1,0 +1,74 @@
+import { createStore, combineReducers, Store } from 'redux'
+import { createSubscriber, createActions, Modeler } from '../src/index'
+
+describe('createSubscriber', () => {
+  // @ Actions
+
+  function tick() {
+    const date = new Date()
+    const month = date.getMonth() + 1
+    const _date = date.getDate()
+    const hour = date.getHours()
+    const minute = date.getMinutes()
+    const second = date.getSeconds()
+    return `${month}/${_date} ${hour}:${minute}:${second}`
+  }
+  const TimerAC = { tick }
+
+  // @ Model
+
+  interface SubscriberST {
+    now: string
+    name: string
+  }
+  const SubscriberModel: Modeler<SubscriberST> = injects => ({
+    now: '',
+    name: 'unknown',
+    ...injects
+  })
+  const subscriptions = {
+    tick(state: SubscriberST, now: string) {
+      return { ...state, now }
+    },
+    setName(state: SubscriberST, name: string) {
+      return { ...state, name }
+    }
+  }
+
+  // @ Aggregates
+
+  const namespace = 'timer/'
+  const Timer = createActions(TimerAC, namespace)
+  const Subscriber1 = createSubscriber()
+  const Subscriber2 = createSubscriber()
+  Subscriber1.subscribe(Timer, subscriptions)
+  Subscriber2.subscribe(Timer, subscriptions)
+
+  // ______________________________________________________
+
+  describe('reducerFactory', () => {
+    interface StoreST {
+      subscriber1: SubscriberST
+      subscriber2: SubscriberST
+    }
+    const store: Store<StoreST> = createStore(
+      combineReducers({
+        subscriber1: Subscriber1.reducerFactory(SubscriberModel({ name: 'USER_1' })),
+        subscriber2: Subscriber2.reducerFactory(SubscriberModel({ name: 'USER_2' }))
+      })
+    )
+
+    test('subscribers update by providers action', () => {
+      const { type, payload } = Timer.creators.tick()
+      const beforeState = store.getState()
+      expect(beforeState.subscriber1.now).not.toEqual(payload)
+      expect(beforeState.subscriber2.now).not.toEqual(payload)
+
+      store.dispatch({ type, payload })
+
+      const afterState = store.getState()
+      expect(afterState.subscriber1.now).toEqual(payload)
+      expect(afterState.subscriber2.now).toEqual(payload)
+    })
+  })
+})

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -53,9 +53,7 @@ import { TodoModel, TodoST } from './todo'
 function addTodo(state: TodosST): TodosST {
   const value = TodosQR.getInputValue(state)
   if (value === '') return state
-  const todo = TodoModel({ value })
-  const items = [...state.items]
-  items.push(todo)
+  const items = [...state.items, TodoModel({ value })]
   return { ...state, items, input: '' }
 }
 ```

--- a/examples/todos/src/models/todos.ts
+++ b/examples/todos/src/models/todos.ts
@@ -40,9 +40,7 @@ export const TodosQR = {
 function addTodo(state: TodosST): TodosST {
   const value = TodosQR.getInputValue(state)
   if (value === '') return state
-  const todo = TodoModel({ value })
-  const items = [...state.items]
-  items.push(todo)
+  const items = [...state.items, TodoModel({ value })]
   return { ...state, items, input: '' }
 }
 function setInputValue(state: TodosST, value: string): TodosST {

--- a/examples/with-rx/src/models/todos.ts
+++ b/examples/with-rx/src/models/todos.ts
@@ -40,9 +40,7 @@ export const TodosQR = {
 function addTodo(state: TodosST): TodosST {
   const value = TodosQR.getInputValue(state)
   if (value === '') return state
-  const todo = TodoModel({ value })
-  const items = [...state.items]
-  items.push(todo)
+  const items = [...state.items, TodoModel({ value })]
   return { ...state, items, input: '' }
 }
 function setInputValue(state: TodosST, value: string): TodosST {

--- a/examples/with-saga/src/actions/timer.ts
+++ b/examples/with-saga/src/actions/timer.ts
@@ -7,4 +7,7 @@ function tick() {
   const second = date.getSeconds()
   return `${month}/${_date} ${hour}:${minute}:${second}`
 }
-export const TimerAC = { tick }
+function notifyMessage({ message }: { message: string }) {
+  return { message }
+}
+export const TimerAC = { tick, notifyMessage }

--- a/examples/with-saga/src/models/todos.ts
+++ b/examples/with-saga/src/models/todos.ts
@@ -40,9 +40,7 @@ export const TodosQR = {
 function addTodo(state: TodosST): TodosST {
   const value = TodosQR.getInputValue(state)
   if (value === '') return state
-  const todo = TodoModel({ value })
-  const items = [...state.items]
-  items.push(todo)
+  const items = [...state.items, TodoModel({ value })]
   return { ...state, items, input: '' }
 }
 function setInputValue(state: TodosST, value: string): TodosST {

--- a/examples/with-saga/src/store.ts
+++ b/examples/with-saga/src/store.ts
@@ -8,7 +8,7 @@ import {
 } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import createSagaMiddleware from 'redux-saga'
-import { createAggregate, createActions } from 'redux-aggregate'
+import { createAggregate, createActions, createSubscriber } from '../../../src'
 import { TimerAC } from './actions/timer'
 import { CounterModel, CounterST, CounterMT, CounterSB } from './models/counter'
 import { TodosModel, TodosST, TodosMT, TodosSB } from './models/todos'
@@ -33,7 +33,7 @@ export interface StoreST {
 export const Timer = createActions(TimerAC, 'timer/')
 export const Counter = createAggregate(CounterMT, 'counter/')
 export const Todos = createAggregate(TodosMT, 'todos/')
-export const Summary = createAggregate({}, 'summary/')
+export const Summary = createSubscriber()
 Todos.subscribe(Timer, TodosSB.Timer)
 Counter.subscribe(Timer, CounterSB.Timer)
 Summary.subscribe(Timer, SummarySB.Timer)

--- a/src/createAggregate.ts
+++ b/src/createAggregate.ts
@@ -1,14 +1,16 @@
 import { Reducer } from 'redux'
 import { namespaced } from './namespaced'
 import { KeyMap } from '../typings/utils'
-import { ActionTypes } from '../typings/commons'
+import {
+  ActionTypes,
+  ReducerFactory,
+  ActionProvider,
+  Subscriptions
+} from '../typings/commons'
 import {
   Mutations,
   ActionCreators,
-  ReducerFactory,
-  Aggregate,
-  ActionProvider,
-  Subscriptions
+  Aggregate
 } from '../typings/createAggregate'
 
 // ______________________________________________________

--- a/src/createSubscriber.ts
+++ b/src/createSubscriber.ts
@@ -1,0 +1,40 @@
+import { Reducer } from 'redux'
+import { KeyMap } from '../typings/utils'
+import {
+  ReducerFactory,
+  ActionProvider,
+  Subscriptions
+} from '../typings/commons'
+import { Subscriber } from '../typings/createSubscriber'
+
+// ______________________________________________________
+
+function createSubscriber(): Subscriber {
+  const __srcmap__: KeyMap = {}
+  function reducerFactory<S>(initialState: S): Reducer<S> {
+    return (state = initialState, action) => {
+      const mutator = __srcmap__[action.type]
+      if (typeof mutator !== 'function') return state
+      return mutator(state, action.payload)
+    }
+  }
+  function subscribe<
+    T extends ActionProvider<T>,
+    M extends Subscriptions<T, M>
+  >(provider: T, subscriptions: M) {
+    Object.keys(subscriptions).forEach(key => {
+      const type = `${provider.__namespace__}${key}`
+      __srcmap__[type] = (subscriptions as KeyMap)[key]
+    })
+  }
+  return {
+    reducerFactory: reducerFactory as ReducerFactory,
+    subscribe
+  }
+}
+
+// ______________________________________________________
+
+type Modeler<T> = (injects?: Partial<T>) => T
+
+export { createSubscriber, Modeler }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { createActions } from './createActions'
 import { createAggregate, Modeler } from './createAggregate'
-export { createActions, createAggregate, Modeler }
+import { createSubscriber } from './createSubscriber'
+export { createActions, createAggregate, createSubscriber, Modeler }

--- a/typings/commons.d.ts
+++ b/typings/commons.d.ts
@@ -1,6 +1,42 @@
+import { Reducer } from 'redux'
+import { KeyMap, R, A1, A2, DiffKey, HasKeysDiff } from './utils'
+import { Aggregate } from './createAggregate'
+import { Actions } from './createActions'
+
 type ActionType = string
 type ActionTypes<T> = { readonly [K in keyof T]: ActionType }
+type ReducerFactory = <S>(state: S) => Reducer<S>
 
 // ______________________________________________________
 
-export { ActionType, ActionTypes }
+type HasKeysDiffErrorMessage = 'SUBSCRIPTIONS_KEY_NOT_MATCH'
+type PayloadErrorMessage = 'PAYLOAD_SCHEMA_NOT_MATCH'
+type SubscribeActions<T, M> = R<T> extends A2<M> ? M : PayloadErrorMessage
+type SubscribeAggregate<T, M> = A2<M> extends A2<T> ? M : PayloadErrorMessage
+type SubscribeActionsMap<T, M> = HasKeysDiff<T, M> extends false
+  ? { [K in keyof T & keyof M]?: SubscribeActions<T[K], M[K]> } & KeyMap
+  : HasKeysDiffErrorMessage
+type SubscribeAggregateMap<T, M> = HasKeysDiff<T, M> extends false
+  ? { [K in keyof T & keyof M]?: SubscribeAggregate<T[K], M[K]> } & KeyMap
+  : HasKeysDiffErrorMessage
+
+// ______________________________________________________
+
+type ISM = { __srcmap__: any }
+type SrcMap<T extends ISM> = T['__srcmap__']
+type ActionProvider<T extends ISM> = Aggregate<SrcMap<T>> | Actions<SrcMap<T>>
+type Subscriptions<T extends ISM, M> = T extends Aggregate<SrcMap<T>>
+  ? SubscribeAggregateMap<SrcMap<T>, M>
+  : SubscribeActionsMap<SrcMap<T>, M>
+
+// ______________________________________________________
+
+export {
+  ActionType,
+  ActionTypes,
+  ReducerFactory,
+  SubscribeAggregateMap,
+  SubscribeActionsMap,
+  ActionProvider,
+  Subscriptions
+}

--- a/typings/createAggregate.d.ts
+++ b/typings/createAggregate.d.ts
@@ -1,6 +1,11 @@
-import { Reducer } from 'redux'
-import { KeyMap, R, A1, A2, DiffKey, HasKeysDiff } from './utils'
-import { ActionType, ActionTypes } from './commons'
+import { KeyMap, A1, A2 } from './utils'
+import {
+  ActionType,
+  ActionTypes,
+  ReducerFactory,
+  ActionProvider,
+  Subscriptions
+} from './commons'
 import { Actions, ActionsSrc } from './createActions'
 
 // ______________________________________________________
@@ -17,28 +22,6 @@ type ActionCreators<T> = { readonly [K in keyof T]: ActionCreator<T[K]> }
 
 // ______________________________________________________
 
-type HasKeysDiffErrorMessage = 'SUBSCRIPTIONS_KEY_NOT_MATCH'
-type PayloadErrorMessage = 'PAYLOAD_SCHEMA_NOT_MATCH'
-type ReducerFactory = <S>(state: S) => Reducer<S>
-type SubscribeActions<T, M> = R<T> extends A2<M> ? M : PayloadErrorMessage
-type SubscribeAggregate<T, M> = A2<M> extends A2<T> ? M : PayloadErrorMessage
-type SubscribeActionsMap<T, M> = HasKeysDiff<T, M> extends false
-  ? { [K in keyof T & keyof M]?: SubscribeActions<T[K], M[K]> } & KeyMap
-  : HasKeysDiffErrorMessage
-type SubscribeAggregateMap<T, M> = HasKeysDiff<T, M> extends false
-  ? { [K in keyof T & keyof M]?: SubscribeAggregate<T[K], M[K]> } & KeyMap
-  : HasKeysDiffErrorMessage
-
-// ______________________________________________________
-
-type ISM = { __srcmap__: any }
-type SrcMap<T extends ISM> = T['__srcmap__']
-type ActionProvider<T extends ISM> =
-  | Aggregate<SrcMap<T>>
-  | Actions<SrcMap<T>>
-type Subscriptions<T extends ISM, M> = T extends Aggregate<SrcMap<T>>
-  ? SubscribeAggregateMap<SrcMap<T>, M>
-  : SubscribeActionsMap<SrcMap<T>, M>
 interface Aggregate<T> {
   readonly __namespace__: string
   readonly __srcmap__: T
@@ -58,15 +41,4 @@ declare function createAggregate<T extends KeyMap & Mutations<T>>(
   namespace: string
 ): Aggregate<T>
 
-type Modeler<T> = (injects?: Partial<T>) => T
-
-export {
-  Mutations,
-  ActionCreators,
-  ReducerFactory,
-  Aggregate,
-  ActionProvider,
-  Subscriptions,
-  createAggregate,
-  Modeler
-}
+export { Mutations, ActionCreators, Aggregate, createAggregate }

--- a/typings/createSubscriber.ts
+++ b/typings/createSubscriber.ts
@@ -1,0 +1,17 @@
+import { ReducerFactory, ActionProvider, Subscriptions } from './commons'
+
+// ______________________________________________________
+
+interface Subscriber {
+  readonly reducerFactory: ReducerFactory
+  subscribe: <T extends ActionProvider<T>, M extends Subscriptions<T, M>>(
+    provider: T,
+    subscriptions: M
+  ) => void
+}
+
+// ______________________________________________________
+
+declare function createSubscriber(): Subscriber
+
+export { Subscriber, createSubscriber }


### PR DESCRIPTION
## Available feature

Currently, Aggregate used empty mutations and unnecessary namespace, even if only subscribing.

```javascript
export const Timer = createActions(TimerAC, 'timer/')
export const Summary = createAggregate({}, 'summary/')
Summary.subscribe(Timer, SummarySB.Timer)
```
Available `createSubscriber` provide only `reducerFactory` and `subscribe` method.
It can avoid securing unnecessary namespaces.

```javascript
export const Timer = createActions(TimerAC, 'timer/')
export const Summary = createSubscriber()
Summary.subscribe(Timer, SummarySB.Timer)
```
